### PR TITLE
update npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 additional date-time classes that complement those in js-joda
 ==============================================
 
-[![npm version](https://badge.fury.io/js/js-joda-locale.svg)](https://badge.fury.io/js/js-joda-locale)
+[![npm version](https://badge.fury.io/js/%40js-joda%2Flocale.svg)](https://badge.fury.io/js/%40js-joda%2Flocale)
 [![Build Status](https://travis-ci.org/js-joda/js-joda-locale.svg?branch=master)](https://travis-ci.org/js-joda/js-joda-locale)
 ![Sauce Test Status](https://saucelabs.com/buildstatus/js-joda-locale)
 [![Coverage Status](https://coveralls.io/repos/js-joda/js-joda-locale/badge.svg?branch=master&service=github)](https://coveralls.io/github/js-joda/js-joda-locale?branch=master)


### PR DESCRIPTION
Version 2.0.0 of @js-joda/locale changed the NPM package name, but the README still contained a badge using the old package name. This updates the README to link to the current package and version.